### PR TITLE
Introduction of CMake project and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+cmake-build*
+build
+
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,11 @@ target_link_libraries(main PRIVATE vinc)
 ###############################################################################
 
 pybind11_add_module(vinc_cpp MODULE vinc.cpp)
+
+###############################################################################
+# Installation
+###############################################################################
+
+install(TARGETS main DESTINATION bin)
+install(TARGETS vinc vinc_cpp DESTINATION lib)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/ext/ DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(vinc PUBLIC m)
 set_property(TARGET vinc PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(vinc_cpp SHARED src/vinc.cpp src/ext/vinc.hpp)
-target_include_directories(vinc PUBLIC src/ext)
+target_include_directories(vinc_cpp PUBLIC src/ext)
 set_property(TARGET vinc PROPERTY POSITION_INDEPENDEN_CODE ON)
 
 add_executable(main src/main.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,27 @@
 cmake_minimum_required(VERSION 3.28)
-project(vincenty)
+
+###############################################################################
+# Project setup
+###############################################################################
+
+project(vincenty
+        LANGUAGES C CXX
+)
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ version selection")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+###############################################################################
+# External dependencies setup
+###############################################################################
+
+# This needs python development headers and pybind installed
+find_package(Python 3.11 COMPONENTS Interpreter Development REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+###############################################################################
+# C Library and executable
+###############################################################################
 
 add_library(vinc SHARED src/vinc.c src/ext/vinc.h)
 target_include_directories(vinc PUBLIC src/ext)
@@ -8,3 +30,9 @@ set_property(TARGET vinc PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_executable(main src/main.c)
 target_link_libraries(main PRIVATE vinc)
+
+###############################################################################
+# C++ Library and Python extension module
+###############################################################################
+
+pybind11_add_module(vinc_cpp MODULE vinc.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ target_include_directories(vinc PUBLIC src/ext)
 target_link_libraries(vinc PUBLIC m)
 set_property(TARGET vinc PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+add_library(vinc_cpp SHARED src/vinc.cpp src/ext/vinc.hpp)
+target_include_directories(vinc PUBLIC src/ext)
+set_property(TARGET vinc PROPERTY POSITION_INDEPENDEN_CODE ON)
+
 add_executable(main src/main.c)
 target_link_libraries(main PRIVATE vinc)
 
@@ -35,7 +39,8 @@ target_link_libraries(main PRIVATE vinc)
 # C++ Library and Python extension module
 ###############################################################################
 
-pybind11_add_module(vinc_cpp MODULE vinc.cpp)
+pybind11_add_module(vinc_cpp_pybind11 MODULE src/vinc.cpp)
+target_compile_definitions(vinc_cpp_pybind11 PRIVATE VINC_PYBIND11=1)
 
 ###############################################################################
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.28)
+project(vincenty)
+
+add_library(vinc SHARED src/vinc.c src/ext/vinc.h)
+target_include_directories(vinc PUBLIC src/ext)
+target_link_libraries(vinc PUBLIC m)
+set_property(TARGET vinc PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+add_executable(main src/main.c)
+target_link_libraries(main PRIVATE vinc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(main PRIVATE vinc)
 
 pybind11_add_module(vinc_cpp_pybind11 MODULE src/vinc.cpp)
 target_compile_definitions(vinc_cpp_pybind11 PRIVATE VINC_PYBIND11=1)
+target_include_directories(vinc_cpp_pybind11 PUBLIC src/ext)
 
 ###############################################################################
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Python 3.11 COMPONENTS Interpreter Development REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 
+find_package(Catch2 3 REQUIRED)
+
 ###############################################################################
 # C Library and executable
 ###############################################################################
@@ -39,9 +41,28 @@ target_link_libraries(main PRIVATE vinc)
 # C++ Library and Python extension module
 ###############################################################################
 
-pybind11_add_module(vinc_cpp_pybind11 MODULE src/vinc.cpp)
+pybind11_add_module(vinc_cpp_pybind11 MODULE src/vinc.cpp src/ext/vinc.hpp)
 target_compile_definitions(vinc_cpp_pybind11 PRIVATE VINC_PYBIND11=1)
 target_include_directories(vinc_cpp_pybind11 PUBLIC src/ext)
+
+###############################################################################
+# Unit Tests
+###############################################################################
+
+add_executable(tests_cpp src/tests/test_vinc.cpp)
+target_link_libraries(tests_cpp
+        PRIVATE
+        Catch2::Catch2WithMain
+        vinc_cpp
+)
+
+add_executable(tests_c src/tests/test_vinc.cpp)
+target_link_libraries(tests_c
+        PRIVATE
+        Catch2::Catch2WithMain
+        vinc
+)
+target_compile_definitions(tests_c PRIVATE VINC_C)
 
 ###############################################################################
 # Installation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gcc -O3 -shared -lm -Wl,-soname,vinc -o vinc.so -fPIC main.c
 
 ### Compile c++ code to an extension module
 ```
-c++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` vinc.cpp -o vinc_cpp`python3-config --extension-suffix` -I /usr/include/python3.6
+c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) vinc.cpp -o vinc_cpp$(python3-config --extension-suffix) -I /usr/include/python3.6
 ```
 
 ### Generate test results

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cmake --install build --prefix ./install
 
 Alternatively you could build directly with GCC:
 ```
-gcc -O3 -shared -lm -Wl,-soname,vinc -o vinc.so -fPIC main.c
+gcc -O3 -shared -lm -Wl,-soname,vinc -o vinc.so -fPIC -Isrc/ext src/vinc.c
 ```
 
 ### Compile c++ code to an extension module
@@ -35,7 +35,7 @@ The vinc_cpp Python extension module can be built by CMake like the vinc C libra
 
 If you insist, you can build it manually with (adapt to local paths or versions):
 ```
-c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) vinc.cpp -o vinc_cpp$(python3-config --extension-suffix) -I /usr/include/python3.11
+c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) src/vinc.cpp -Isrc/ext -o vinc_cpp$(python3-config --extension-suffix) -I /usr/include/python3.11
 ```
 
 ### Generate test results

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This repository contains Vincenty's formula in
 The formula calculates the azimuth and distance between two points on the surface of a spheroid.
 For more information about the formula see: https://en.wikipedia.org/wiki/Vincenty's_formulae
 
+## License and usage
+
+Licensed under GPLv3.
+If you use the program for something cool, I'd love to hear about it!
+Please report any problems, ideas, etc. as an issue.
+
 ### Compile C code to a shared library
 
 CMake is the preferred way to build and install the library:
@@ -33,7 +39,22 @@ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) vinc.cp
 ```
 
 ### Generate test results
-Execute the vinc_c_vs_python.py file
+
+The script requires you to build vinc and vinc_cpp. 
+Execute the vinc_c_vs_python.py file, see --help for options:
+```
+./vinc_c_vs_python.py --help
+usage: VincentyCompare [-h] VINC_SO VINC_CPP
+
+Vincenty Comparison Python vs C
+
+positional arguments:
+  VINC_SO     Path to vinc shared library file to use, typically libvinc.so.
+  VINC_CPP    Path to C++ Python extension module, for example vinc_cpp.cpython-311-x86_64-linux-gnu.so.
+
+options:
+  -h, --help  show this help message and exit
+```
 
 On a Xeon E3-1246v3 @ 3.50GHz
 ```
@@ -49,7 +70,7 @@ C results:      559567.3915137552 -3.021053212988765
 C++ results:    559580.5061678728 -3.0210528410061204
 ```
 
-### Conclusion
+## Conclusion
 
 Numpy is slower than pure Python since only scalars are used during the calculation.
 C takes 1.1 µs per function call, C++ 0.6 µs and python 10 µs. Binding the extension with pybind11 requires less boilerplate code than ctypes, and is not less efficient. The generated module is larger though (122 kB in C++ vs 16 kB for C).

--- a/README.md
+++ b/README.md
@@ -9,14 +9,27 @@ This repository contains Vincenty's formula in
 The formula calculates the azimuth and distance between two points on the surface of a spheroid.
 For more information about the formula see: https://en.wikipedia.org/wiki/Vincenty's_formulae
 
-### Compile C code to a shared library 
+### Compile C code to a shared library
+
+CMake is the preferred way to build and install the library:
+```
+cmake -B build -S .
+cmake --build build --target vinc
+cmake --install build --prefix ./install
+```
+
+Alternatively you could build directly with GCC:
 ```
 gcc -O3 -shared -lm -Wl,-soname,vinc -o vinc.so -fPIC main.c
 ```
 
 ### Compile c++ code to an extension module
+
+The vinc_cpp Python extension module can be built by CMake like the vinc C library. 
+
+If you insist, you can build it manually with (adapt to local paths or versions):
 ```
-c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) vinc.cpp -o vinc_cpp$(python3-config --extension-suffix) -I /usr/include/python3.6
+c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) vinc.cpp -o vinc_cpp$(python3-config --extension-suffix) -I /usr/include/python3.11
 ```
 
 ### Generate test results

--- a/main.c
+++ b/main.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <math.h>
-#include <stdlib.h>
 
 struct Result{
     double value1;

--- a/main.c
+++ b/main.c
@@ -1,25 +1,30 @@
 #include <stdio.h>
 #include <math.h>
 
-struct Result{
-    double value1;
-    double value2;
+struct ResultVinc {
+    double distance;
+    double azimuth;
 };
 
-typedef struct geom {
-    double sin_sigma, cos_sigma, sigma, sin_alpha, cos_sq_alpha, cos2sigma;
-} geom; 
+struct Geom {
+    double sin_sigma;
+    double cos_sigma;
+    double sigma;
+    double sin_alpha;
+    double cos_sq_alpha;
+    double cos2sigma;
+};
 
-void calcgeo(geom *g, double lam, double u1, double u2) {
-
-    (*g).sin_sigma = sqrt(pow((cos(u2) * sin(lam)), 2.) + pow(cos(u1)*sin(u2) - sin(u1)*cos(u2)*cos(lam), 2.));
-    (*g).cos_sigma = sin(u1) * sin(u2) + cos(u1) * cos(u2) * cos(lam);
-    (*g).sigma = atan((*g).sin_sigma / (*g).cos_sigma);
-    if ((*g).sigma <= 0) (*g).sigma = M_PI + (*g).sigma;
-    (*g).sin_alpha = (cos(u1) * cos(u2) * sin(lam)) / (*g).sin_sigma;
-    (*g).cos_sq_alpha = 1 - pow((*g).sin_alpha, 2.);
-    (*g).cos2sigma = (*g).cos_sigma - ((2 * sin(u1) * sin(u2)) / (*g).cos_sq_alpha);
-
+void calcgeo(struct Geom *g, double lam, double u1, double u2) {
+    g->sin_sigma = sqrt(pow((cos(u2) * sin(lam)), 2.) + pow(cos(u1) * sin(u2) - sin(u1) * cos(u2) * cos(lam), 2.));
+    g->cos_sigma = sin(u1) * sin(u2) + cos(u1) * cos(u2) * cos(lam);
+    g->sigma = atan(g->sin_sigma / g->cos_sigma);
+    if (g->sigma <= 0) {
+        g->sigma += M_PI;
+    }
+    g->sin_alpha = (cos(u1) * cos(u2) * sin(lam)) / g->sin_sigma;
+    g->cos_sq_alpha = 1 - pow(g->sin_alpha, 2.);
+    g->cos2sigma = g->cos_sigma - ((2 * sin(u1) * sin(u2)) / g->cos_sq_alpha);
 };
 
 /**
@@ -32,12 +37,10 @@ void calcgeo(geom *g, double lam, double u1, double u2) {
  * @param longc Longitude
  * @return
  */
-struct Result vinc(double latp, double latc, double longp, double longc) {
-
-    geom gvar;
-
-    double req = 6378137.0;             //Radius at equator
-    double flat = 1 / 298.257223563;    //flattenig of earth
+struct ResultVinc vinc(double latp, double latc, double longp, double longc) {
+    struct Geom gvar;
+    double req = 6378137.0;             // Radius at equator
+    double flat = 1 / 298.257223563;    // Flattening of earth
     double rpol = (1 - flat) * req;
 
     double u1, u2, lon, lam, tol, diff;
@@ -54,7 +57,7 @@ struct Result vinc(double latp, double latc, double longp, double longc) {
 
     lon = longp - longc;
     lam = lon;
-    tol = pow(10., -12.); // iteration tolerance
+    tol = pow(10., -12.); // Iteration tolerance, 10E-12 corresponds to approx. 0.06 mm
     diff = 1.;
 
     while (fabs(diff) > tol) {
@@ -76,9 +79,14 @@ struct Result vinc(double latp, double latc, double longp, double longc) {
     dis = rpol * A * (gvar.sigma - delta_sig);
     azi1 = atan2((cos(u2) * sin(lam)), (cos(u1) * sin(u2) - sin(u1) * cos(u2) * cos(lam)));
 
-    struct Result res = {dis, azi1};
-    return(res);
+    struct ResultVinc r = {dis, azi1};
+    return r;
 }
+
+struct ResultTrans {
+    double x;
+    double y;
+};
 
 /**
  * Transform longitude, latitude coordinates of two points to x,y coordinates
@@ -88,29 +96,25 @@ struct Result vinc(double latp, double latc, double longp, double longc) {
  * @param longc
  * @return
  */
-struct Result trans(double latp, double latc, double longp, double longc){
+struct ResultTrans trans(double latp, double latc, double longp, double longc){
 
-    double rav, theta, dis, azi, xy, x, y;
-    struct Result dis_azi;
+    double rav, theta, xy, x, y;
+    struct ResultVinc dis_azi;
 
-    rav = 6371000.0;  //average radius
+    rav = 6371000.0;  // average radius
     dis_azi = vinc(latp,latc,longp,longc);
 
-    dis = dis_azi.value1;
-    azi = dis_azi.value2;
-
-    theta = dis/rav; //finding theta angle
-    xy = sin(theta)*rav; //length in xy plane
-
-    y = xy*cos(azi); //lat for chunk
-    x = xy*sin(azi); //long for chunk
-    struct Result res = {y, x};
-    return(res);
+    theta = dis_azi.distance / rav; // finding theta angle
+    xy = sin(theta) * rav; // length in xy plane
+    y = xy * cos(dis_azi.distance); // lat for chunk
+    x = xy * sin(dis_azi.azimuth); // long for chunk
+    struct ResultTrans r = {x, y};
+    return r;
 }
 
 int main() {
     // Testing with one value
-    struct Result res = trans(40.99698, 46.0, 9.20127, 10.0);
-    printf("%f - %f\n", res.value1, res.value2);
+    struct ResultTrans res = trans(40.99698, 46.0, 9.20127, 10.0);
+    printf("%f - %f\n", res.x, res.y);
     return 0;
 }

--- a/src/ext/vinc.h
+++ b/src/ext/vinc.h
@@ -1,0 +1,37 @@
+#pragma once
+
+
+struct ResultVinc {
+    double distance;
+    double azimuth;
+};
+
+
+struct ResultTrans {
+    double x;
+    double y;
+};
+
+
+/**
+ * Vincenty's formulae for distance, solving the inverse problem.
+ * Calculates distance and azimuth between two points on the surface of a spheroid.
+ * For more information see: https://en.wikipedia.org/wiki/Vincenty%27s_formulae
+ * @param latp Latitude
+ * @param latc Latitude
+ * @param longp Longitude
+ * @param longc Longitude
+ * @return
+ */
+struct ResultVinc vinc(double latp, double latc, double longp, double longc);
+
+
+/**
+ * Transform longitude, latitude coordinates of two points to x,y coordinates
+ * @param latp
+ * @param latc
+ * @param longp
+ * @param longc
+ * @return
+ */
+struct ResultTrans trans(double latp, double latc, double longp, double longc);

--- a/src/ext/vinc.h
+++ b/src/ext/vinc.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C"{
+#endif
 
 struct ResultVinc {
     double distance;
@@ -35,3 +38,8 @@ struct ResultVinc vinc(double latp, double latc, double longp, double longc);
  * @return
  */
 struct ResultTrans trans(double latp, double latc, double longp, double longc);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ext/vinc.hpp
+++ b/src/ext/vinc.hpp
@@ -1,0 +1,3 @@
+#include <tuple>
+
+std::tuple<double, double> vinc(double latp, double latc, double longp, double longc);

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,9 @@
+#include "stdio.h"
+#include "vinc.h"
+
+int main() {
+    // Testing with one value
+    struct ResultTrans res = trans(40.99698, 46.0, 9.20127, 10.0);
+    printf("%f - %f\n", res.x, res.y);
+    return 0;
+}

--- a/src/tests/test_vinc.cpp
+++ b/src/tests/test_vinc.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+
+// Has to be placed before the catch2 includes to be registered by them.
+std::ostream &operator<<(std::ostream &os, const std::tuple<double, double> &value) {
+    os << "azimuth: " << std::get<0>(value) << ", distance: " << std::get<1>(value);
+    return os;
+}
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#ifdef VINC_C
+#include "vinc.h"
+#else
+#include "vinc.hpp"
+#endif
+
+TEST_CASE("Zero distance with zero input") {
+    auto [distance, azimuth] = vinc(0, 0, 0, 0);
+    REQUIRE(distance == 0);
+    REQUIRE(azimuth == 0);
+}
+
+TEST_CASE("Zero distance with non zero input") {
+    auto [distance, azimuth] = vinc(99, 99, 99, 99);
+    REQUIRE(distance == 0);
+    REQUIRE(azimuth == 0);
+}
+
+TEST_CASE("One degree distance is ~ 111 km") {
+    auto [distance, azimuth] = vinc(0, 0, 0, 1);
+    REQUIRE_THAT(distance, Catch::Matchers::WithinAbs(111319.491, 0.001));
+}
+
+TEST_CASE("Nearly antipodal points") {
+    auto [distance, azimuth] = vinc(0, 0.5, 0, 179.5);
+    REQUIRE_THAT(distance, Catch::Matchers::WithinAbs(19936288.579, 0.001));
+}

--- a/src/vinc.c
+++ b/src/vinc.c
@@ -23,7 +23,11 @@ void calcgeo(struct Geom *g, double lam, double u1, double u2) {
     }
     g->sin_alpha = (cos(u1) * cos(u2) * sin(lam)) / g->sin_sigma;
     g->cos_sq_alpha = 1 - pow(g->sin_alpha, 2.);
-    g->cos2sigma = g->cos_sigma - ((2 * sin(u1) * sin(u2)) / g->cos_sq_alpha);
+    if (g->cos_sq_alpha == 0) {
+        g->cos2sigma = 0;
+    } else {
+        g->cos2sigma = g->cos_sigma - ((2 * sin(u1) * sin(u2)) / g->cos_sq_alpha);
+    }
 }
 
 
@@ -35,6 +39,12 @@ struct ResultVinc vinc(double latp, double latc, double longp, double longc) {
 
     double u1, u2, lon, lam, tol, diff;
     double A, B, C, lam_pre, delta_sig, dis, azi1, usq;
+
+    if (latp == latc && longp == longc) {
+        // Coincident points
+        struct ResultVinc r = {0, 0};
+        return r;
+    }
 
     // convert to radians
     latp = M_PI * latp / 180.0;
@@ -64,7 +74,7 @@ struct ResultVinc vinc(double latp, double latc, double longp, double longc) {
     A = 1 + (usq / 16384) * (4096 + usq * (-768 + usq * (320 - 175 * usq)));
     B = (usq / 1024) * (256 + usq * (-128 + usq * (74 - 47 * usq)));
     delta_sig = B * gvar.sin_sigma * (gvar.cos2sigma + 0.25 * B * (gvar.cos_sigma * (-1 + 2 * pow(gvar.cos2sigma, 2.)) -
-                                                                   (1 / 6) * B * gvar.cos2sigma * (-3 + 4 * pow(gvar.sin_sigma, 2.)) *
+                                                                   (1. / 6) * B * gvar.cos2sigma * (-3 + 4 * pow(gvar.sin_sigma, 2.)) *
                                                                    (-3 + 4 * pow(gvar.cos2sigma, 2.))));
     dis = rpol * A * (gvar.sigma - delta_sig);
     azi1 = atan2((cos(u2) * sin(lam)), (cos(u1) * sin(u2) - sin(u1) * cos(u2) * cos(lam)));

--- a/src/vinc.c
+++ b/src/vinc.c
@@ -1,10 +1,8 @@
+#include "vinc.h"
+
 #include <stdio.h>
 #include <math.h>
 
-struct ResultVinc {
-    double distance;
-    double azimuth;
-};
 
 struct Geom {
     double sin_sigma;
@@ -14,6 +12,7 @@ struct Geom {
     double cos_sq_alpha;
     double cos2sigma;
 };
+
 
 void calcgeo(struct Geom *g, double lam, double u1, double u2) {
     g->sin_sigma = sqrt(pow((cos(u2) * sin(lam)), 2.) + pow(cos(u1) * sin(u2) - sin(u1) * cos(u2) * cos(lam), 2.));
@@ -25,18 +24,9 @@ void calcgeo(struct Geom *g, double lam, double u1, double u2) {
     g->sin_alpha = (cos(u1) * cos(u2) * sin(lam)) / g->sin_sigma;
     g->cos_sq_alpha = 1 - pow(g->sin_alpha, 2.);
     g->cos2sigma = g->cos_sigma - ((2 * sin(u1) * sin(u2)) / g->cos_sq_alpha);
-};
+}
 
-/**
- * Vincenty's formulae for distance, solving the inverse problem.
- * Calculates distance and azimuth between two points on the surface of a spheroid.
- * For more information see: https://en.wikipedia.org/wiki/Vincenty%27s_formulae
- * @param latp Latitude
- * @param latc Latitude
- * @param longp Longitude
- * @param longc Longitude
- * @return
- */
+
 struct ResultVinc vinc(double latp, double latc, double longp, double longc) {
     struct Geom gvar;
     double req = 6378137.0;             // Radius at equator
@@ -74,8 +64,8 @@ struct ResultVinc vinc(double latp, double latc, double longp, double longc) {
     A = 1 + (usq / 16384) * (4096 + usq * (-768 + usq * (320 - 175 * usq)));
     B = (usq / 1024) * (256 + usq * (-128 + usq * (74 - 47 * usq)));
     delta_sig = B * gvar.sin_sigma * (gvar.cos2sigma + 0.25 * B * (gvar.cos_sigma * (-1 + 2 * pow(gvar.cos2sigma, 2.)) -
-                                                         (1 / 6) * B * gvar.cos2sigma * (-3 + 4 * pow(gvar.sin_sigma, 2.)) *
-                                                         (-3 + 4 * pow(gvar.cos2sigma, 2.))));
+                                                                   (1 / 6) * B * gvar.cos2sigma * (-3 + 4 * pow(gvar.sin_sigma, 2.)) *
+                                                                   (-3 + 4 * pow(gvar.cos2sigma, 2.))));
     dis = rpol * A * (gvar.sigma - delta_sig);
     azi1 = atan2((cos(u2) * sin(lam)), (cos(u1) * sin(u2) - sin(u1) * cos(u2) * cos(lam)));
 
@@ -83,19 +73,7 @@ struct ResultVinc vinc(double latp, double latc, double longp, double longc) {
     return r;
 }
 
-struct ResultTrans {
-    double x;
-    double y;
-};
 
-/**
- * Transform longitude, latitude coordinates of two points to x,y coordinates
- * @param latp
- * @param latc
- * @param longp
- * @param longc
- * @return
- */
 struct ResultTrans trans(double latp, double latc, double longp, double longc){
 
     double rav, theta, xy, x, y;
@@ -110,11 +88,4 @@ struct ResultTrans trans(double latp, double latc, double longp, double longc){
     x = xy * sin(dis_azi.azimuth); // long for chunk
     struct ResultTrans r = {x, y};
     return r;
-}
-
-int main() {
-    // Testing with one value
-    struct ResultTrans res = trans(40.99698, 46.0, 9.20127, 10.0);
-    printf("%f - %f\n", res.x, res.y);
-    return 0;
 }

--- a/src/vinc.cpp
+++ b/src/vinc.cpp
@@ -1,9 +1,11 @@
 #include <tuple>
+#include <cmath>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
 std::tuple<double, double> vinc(double latp, double latc, double longp, double longc) {
+    using namespace std;
     constexpr double req = 6378137.0;             //Radius at equator
     constexpr double flat = 1 / 298.257223563;    //flattening of earth
     constexpr double rpol = (1 - flat) * req;

--- a/src/vinc.cpp
+++ b/src/vinc.cpp
@@ -1,8 +1,10 @@
 #include <tuple>
 #include <cmath>
-#include <pybind11/pybind11.h>
 
+#ifdef VINC_PYBIND11
+#include <pybind11/pybind11.h>
 namespace py = pybind11;
+#endif
 
 std::tuple<double, double> vinc(double latp, double latc, double longp, double longc) {
     using namespace std;
@@ -52,9 +54,10 @@ std::tuple<double, double> vinc(double latp, double latc, double longp, double l
     return std::make_tuple(dis, azi1);
 }
 
-
+#ifdef VINC_PYBIND11
 PYBIND11_MODULE(vinc_cpp, m){
     m.doc() = "Vincentys formula in C++";
 
     m.def("vinc", &vinc, "Vincentys formula");
 }
+#endif

--- a/src/vinc.cpp
+++ b/src/vinc.cpp
@@ -1,3 +1,5 @@
+#include "vinc.hpp"
+
 #include <tuple>
 #include <cmath>
 

--- a/src/vinc.cpp
+++ b/src/vinc.cpp
@@ -39,6 +39,7 @@ std::tuple<double, double> vinc(double latp, double latc, double longp, double l
         }
         cos_sigma = sin(u1) * sin(u2) + cos(u1) * cos(u2) * cos(lam);
         sigma = atan(sin_sigma / cos_sigma);
+        if (sigma <= 0) sigma = M_PI + sigma;
         sin_alpha = (cos(u1) * cos(u2) * sin(lam)) / sin_sigma;
         cos_sq_alpha = 1 - pow(sin_alpha, 2.);
         if (cos_sq_alpha == 0.) {

--- a/vinc.cpp
+++ b/vinc.cpp
@@ -22,7 +22,7 @@ std::tuple<double, double> vinc(double latp, double latc, double longp, double l
 
     double lon = longp - longc;
     double lam = lon;
-    constexpr double tol = pow(10., -12.); // iteration tolerance
+    constexpr double tol = 10.e-12; // iteration tolerance
     double diff = 1.;
 
     while (abs(diff) > tol) {

--- a/vinc_c_vs_python.py
+++ b/vinc_c_vs_python.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-from ctypes import *
+import ctypes
+from ctypes import c_double
 import numpy as np
 import timeit
 from math import sin, cos, atan, atan2, tan, sqrt
@@ -8,10 +9,10 @@ import vinc_cpp
 
 
 # load the library containing the vinc function
-vincer = CDLL("./vinc.so")
+vincer = ctypes.CDLL("./vinc.so")
 
 # vinc function uses a struct containing azimut and distance as members, recreate this
-class Result(Structure):
+class Result(ctypes.Structure):
     _fields_ = [("value1", c_double), ("value2", c_double)]
 # set the expected return type of the function vinc to result
 vincer.vinc.restype = Result

--- a/vinc_c_vs_python.py
+++ b/vinc_c_vs_python.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from ctypes import *
 import numpy as np

--- a/vinc_c_vs_python.py
+++ b/vinc_c_vs_python.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python3
 
+import argparse
 import ctypes
+import pathlib
+import sys
+import types
 from ctypes import c_double
 import numpy as np
 import timeit
 from math import sin, cos, atan, atan2, tan, sqrt
-import vinc_cpp
 
-
-# load the library containing the vinc function
-vincer = ctypes.CDLL("./vinc.so")
 
 # vinc function uses a struct containing azimut and distance as members, recreate this
 class Result(ctypes.Structure):
     _fields_ = [("value1", c_double), ("value2", c_double)]
-# set the expected return type of the function vinc to result
-vincer.vinc.restype = Result
-vincer.trans.restype = Result
+
 
 # vinc numpy math functions
-def vinc_numpy(latp, latc, longp, longc):
+def vinc_numpy(latp: float, latc: float, longp: float, longc: float) -> tuple[float, float]:
 
     req = 6378137.0 #Radius at equator
     flat = 1/298.257223563 #flattenig of earth
@@ -72,7 +70,7 @@ def vinc_numpy(latp, latc, longp, longc):
 
 
 # python implementation of vinc
-def vinc_pure_python(latp, latc, longp, longc):
+def vinc_pure_python(latp: float, latc: float, longp: float, longc: float) -> tuple[float, float]:
 
     req = 6378137.0 #Radius at equator
     flat = 1/298.257223563 #flattenig of earth
@@ -124,7 +122,7 @@ def vinc_pure_python(latp, latc, longp, longc):
     return dis,azi1
 
 
-def trans(latp,latc,longp,longc):
+def trans(latp: float, latc: float, longp:float, longc:float) -> tuple[float, float]:
 
     rav = 6371000.0 #average radius
 
@@ -137,9 +135,9 @@ def trans(latp,latc,longp,longc):
     x = xy*np.sin(azi) #long for chunk
 
     return y, x
-    
 
-def test_vinc():
+
+def test_vinc(vincer: ctypes.CDLL, vinc_cpp: types.ModuleType) -> None:
     number_of_calls = 1000
 
     print("\nTesting function vinc")
@@ -148,26 +146,28 @@ def test_vinc():
     setup_str_python = "latp, latc, longp, longc = 40.99698, 46.0, 9.20127, 10.0; from __main__ import vinc_pure_python"
     # python code which is called
     stmt_python = 'vinc_pure_python(latp, latc, longp, longc)'
-    
+
     # setup for numpy vinc function
     setup_str_numpy = "latp, latc, longp, longc = 40.99698, 46.0, 9.20127, 10.0; from __main__ import vinc_numpy"
     # python code which is called
     stmt_numpy = 'vinc_numpy(latp, latc, longp, longc)'
 
     # setup for c vinc function
-    setup_str_c = "latp, latc, longp, longc = 40.99698, 46.0, 9.20127, 10.0; from __main__ import vincer; from ctypes import c_double"
+    setup_str_c = "latp, latc, longp, longc = 40.99698, 46.0, 9.20127, 10.0"
     # python code which calls c vinc function
     stmt_c = 'vincer.vinc(c_double(latp), c_double(latc), c_double(longp), c_double(longc))'
 
     # setup for the cpp vinc function
-    setup_str_cpp = "latp, latc, longp, longc = 40.99698, 46.0, 9.20127, 10.0; from vinc_cpp import vinc"
+    setup_str_cpp = "latp, latc, longp, longc = 40.99698, 46.0, 9.20127, 10.0"
     # python code to call cpp function
-    stmt_cpp = "vinc(latp, latc, longp, longc)"
+    stmt_cpp = "vinc_cpp.vinc(latp, latc, longp, longc)"
 
     times_python = timeit.repeat(stmt=stmt_python, setup=setup_str_python, repeat=10, number=number_of_calls)
     times_numpy = timeit.repeat(stmt=stmt_numpy, setup=setup_str_numpy, repeat=10, number=number_of_calls)
-    times_c = timeit.repeat(stmt=stmt_c, setup=setup_str_c, repeat=10, number=number_of_calls)
-    times_cpp = timeit.repeat(stmt=stmt_cpp, setup=setup_str_cpp, repeat=10, number=number_of_calls)
+    times_c = timeit.repeat(stmt=stmt_c, setup=setup_str_c, repeat=10, number=number_of_calls,
+                            globals={"vincer": vincer, "c_double": c_double})
+    times_cpp = timeit.repeat(stmt=stmt_cpp, setup=setup_str_cpp, repeat=10, number=number_of_calls,
+                              globals={"vinc_cpp": vinc_cpp})
 
     # calculate time per run
     times_python = [res / number_of_calls for res in times_python]
@@ -185,7 +185,8 @@ def test_vinc():
     # print time and numerical results
     print_results(times_python, times_numpy, times_c, times_cpp, result_python, result_numpy, result_c, result_cpp, number_of_calls)
 
-def test_trans():
+def test_trans(vincer: ctypes.CDLL) -> None:
+    raise RuntimeError("Currently not supported")
     number_of_calls = 1000
 
     print("Testing function trans")
@@ -212,10 +213,25 @@ def test_trans():
     result_python = trans(latp, latc, longp, longc)
     result_c = vincer.trans(c_double(latp), c_double(latc), c_double(longp), c_double(longc))
 
-    # print time and numrical results
+    # print time and numerical results
     print_results(times_python, times_c, result_python, result_c, number_of_calls)
 
-def print_results(times_python, times_numpy, times_c, times_cpp, result_python, result_numpy, result_c, result_cpp, number_of_calls):
+
+def load_vinc_so(so_path: pathlib.Path) -> ctypes.CDLL:
+    # load the library containing the vinc function
+    so_path = so_path.resolve()
+    print(f"Trying to load {so_path}")
+    vincer = ctypes.CDLL(str(so_path))
+    # set the expected return type of the function vinc to result
+    vincer.vinc.restype = Result
+    vincer.trans.restype = Result
+    return vincer
+
+
+def print_results(times_python: list[float], times_numpy: list[float], times_c: list[float], times_cpp: list[float],
+                  result_python: tuple[float, float], result_numpy: tuple[float, float], result_c: tuple[float, float],
+                  result_cpp: Result,
+                  number_of_calls: int) -> None:
     print("NumPy best average out of {} runs:  {:.1E} secs".format(number_of_calls, min(times_numpy)))
     print("Python best average out of {} runs: {:.1E} secs".format(number_of_calls, min(times_python)))
     print("C best average out of {} runs:      {:.1E} secs".format(number_of_calls, min(times_c)))
@@ -225,8 +241,28 @@ def print_results(times_python, times_numpy, times_c, times_cpp, result_python, 
     print("Python results: {} {}".format(*result_python))
     print("C results:      {} {}".format(result_c.value1, result_c.value2))
     print(f"C++ results:    {result_cpp[0]} {result_cpp[1]}")
-    
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="VincentyCompare",
+        description="Vincenty Comparison Python vs C"
+    )
+
+    parser.add_argument("VINC_SO", type=pathlib.Path,
+                        help="Path to vinc shared library file to use, typically libvinc.so.")
+    parser.add_argument("VINC_CPP", type=pathlib.Path,
+                        help="Path to C++ Python extension module, for example vinc_cpp.cpython-311-x86_64-linux-gnu.so.")
+    args = parser.parse_args()
+    vincer = load_vinc_so(args.VINC_SO)
+    vinc_cpp_dir: pathlib.Path = args.VINC_CPP.absolute().parent
+    print(f"Adding {vinc_cpp_dir} to sys.path")
+    sys.path.append(str(vinc_cpp_dir))
+    import vinc_cpp
+
+    test_vinc(vincer, vinc_cpp)
+    #test_trans(vincer)
+
 
 if __name__ == '__main__':
-    test_vinc()
-    #test_trans()
+    main()

--- a/vinc_c_vs_python.py
+++ b/vinc_c_vs_python.py
@@ -37,11 +37,10 @@ def vinc_numpy(latp, latc, longp, longc):
 
     lam = lon
 
-    tol = 10**(-12) # iteration tool
-    diff = 1
+    tol = 10**(-12) # iteration tolerance
+    max_iterations = 1_000_000
 
-    while abs(diff) > tol:
-
+    for _ in range(max_iterations):
         sin_sigma = np.sqrt((np.cos(u2)*np.sin(lam))**2 + (np.cos(u1)*np.sin(u2) - np.sin(u1)*np.cos(u2)*np.cos(lam))**2)
         cos_sigma = np.sin(u1)*np.sin(u2) + np.cos(u1)*np.cos(u2)*np.cos(lam)
         sigma = np.arctan(sin_sigma/cos_sigma)
@@ -53,6 +52,10 @@ def vinc_numpy(latp, latc, longp, longc):
         lam = lon + (1-C)*flat*sin_alpha*(sigma+C*sin_sigma*(cos2sigma + C*cos_sigma*(2*cos2sigma**2 - 1)))
 
         diff = abs(lam_pre - lam)
+        if abs(diff) < tol:
+            break
+    else:
+        raise RuntimeError(f"Tolerance value chosen to large ({tol}).")
 
     usq = cos_sq_alpha*((req**2-rpol**2)/rpol**2)
     A = 1 + (usq/16384)*(4096+usq*(-768+usq*(320-175*usq)))
@@ -87,11 +90,10 @@ def vinc_pure_python(latp, latc, longp, longc):
 
     lam = lon
 
-    tol = 10**(-12) # iteration tool
-    diff = 1
+    tol = 10**(-12) # iteration tolerance
+    max_iterations = 1_000_000
 
-    while abs(diff) > tol:
-
+    for _ in range(max_iterations):
         sin_sigma = sqrt((cos(u2)*sin(lam))**2 + (cos(u1)*sin(u2) - sin(u1)*cos(u2)*cos(lam))**2)
         cos_sigma = sin(u1)*sin(u2) + cos(u1)*cos(u2)*cos(lam)
         sigma = atan(sin_sigma/cos_sigma)
@@ -103,6 +105,10 @@ def vinc_pure_python(latp, latc, longp, longc):
         lam = lon + (1-C)*flat*sin_alpha*(sigma+C*sin_sigma*(cos2sigma + C*cos_sigma*(2*cos2sigma**2 - 1)))
 
         diff = abs(lam_pre - lam)
+        if abs(diff) < tol:
+            break
+    else:
+        raise RuntimeError(f"Tolerance value chosen to large ({tol}).")
 
     usq = cos_sq_alpha*((req**2-rpol**2)/rpol**2)
     A = 1 + (usq/16384)*(4096+usq*(-768+usq*(320-175*usq)))


### PR DESCRIPTION
Add a CMakeLists.txt based project instead of simple compile commands (although they still work and are left in the README). Split project into multiple source and header files and a create adirectory structure.
Add unit test cases using Catch2.
Refactor python speed test script to allow passing location of the compiled binaries instead of the user having to place them in the right location.